### PR TITLE
Use custom Inquirer.js and show previous question in prompts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "open": "0.0.5",
     "optimist": "^0.6.1",
     "q": "^1.1.2",
-    "inquirer": "^1.0.2",
+    "monaca-inquirer": "frankdiox/Inquirer.js",
     "shelljs": "^0.3.0",
     "xmldom": "^0.1.19"
   }


### PR DESCRIPTION
@masahirotanaka Can you check if this is OK? It's a bit hard to modify all of this in Inquirer.js since it relies on other libraries to do everything. Now you can use arrow-right to accept and arrow-left to cancel (same as Esc and Q). It displays an X when a question is canceled and goes to the previous question.

I'd like to modify Inquirer.js properly to have real support for this option but it's not a trivial task. For now I think these changes are enough.
