### PR TITLE
--no-open

### DIFF
--- a/doc/tasks/serve.json
+++ b/doc/tasks/serve.json
@@ -13,7 +13,14 @@
     "usage": "monaca preview [port]",
     "examples": [
       "monaca preview",
-      "monaca preview 8001"
+      "monaca preview 8001",
+      "monaca preview --no-open"
+    ],
+    "options": [
+      [
+        "--no-open",
+        "Do not open browser"
+      ]
     ],
     "showInHelp": true
   }

--- a/doc/tasks/serve.json
+++ b/doc/tasks/serve.json
@@ -7,16 +7,19 @@
       "",
       "Will watch the file-system for changes and reload the",
       "browser when a change occurs.",
-      "",
-      "Port defaults to 8000"
+      ""
     ],
-    "usage": "monaca preview [port]",
+    "usage": "monaca preview",
     "examples": [
       "monaca preview",
-      "monaca preview 8001",
+      "monaca preview -p 8001",
       "monaca preview --no-open"
     ],
     "options": [
+      [
+        "--port, -p",
+        "Port. Defaults to 8000"
+      ],
       [
         "--no-open",
         "Do not open browser"

--- a/src/serve.js
+++ b/src/serve.js
@@ -65,7 +65,17 @@ ServeTask.run = function(taskName) {
           });
       };
 
-      var port = process.argv.length >= 4 ? process.argv[3] : 8000;
+      var port = 8000; var isNotFoundPort = true;
+      var openBrowser = true; var isNotFoundOpenBrowser = true;
+      process.argv.forEach(function(arg, i) {
+        if (isNotFoundPort && i >= 3 && !!arg.match(/^([0-9]+)$/)) {
+          port = arg;
+          isNotFoundPort = false;
+        } else if (isNotFoundOpenBrowser && i >= 3 && arg === '--no-open') {
+          openBrowser = false;
+          isNotFoundOpenBrowser = false;
+        }
+      });
 
       // Execute filewatcher here with transpiler
       var FileWatcher = require(path.join(__dirname, '..', 'node_modules', 'monaca-lib', 'src', 'localkit', 'fileWatcher'));
@@ -93,7 +103,7 @@ ServeTask.run = function(taskName) {
         alive: true
       }, {
         name: 'http-server',
-        process: exec('node' + ' ' + path.join(__dirname, 'serve', 'node_modules', 'http-server', 'bin', 'http-server') + ' ' + path.join(process.cwd(), 'www') + ' -c-1 -o -p ' + port, {cwd: __dirname}),
+        process: exec('node' + ' ' + path.join(__dirname, 'serve', 'node_modules', 'http-server', 'bin', 'http-server') + ' ' + path.join(process.cwd(), 'www') + ' -c-1 ' + (openBrowser ? ' -o ' : '') + ' -p ' + port, {cwd: __dirname}),
         color: 'cyan',
         alive: true
       }

--- a/src/serve.js
+++ b/src/serve.js
@@ -6,7 +6,11 @@ var path = require('path'),
   fs = require('fs'),
   Q = require('q'),
   util = require(path.join(__dirname, 'util')),
-  Monaca = require('monaca-lib').Monaca;
+  Monaca = require('monaca-lib').Monaca,
+  argv = require('optimist')
+    .alias('p', 'port')
+    .default('open', true)
+    .argv;
 
 var ServeTask = {};
 var monaca = new Monaca();
@@ -65,18 +69,6 @@ ServeTask.run = function(taskName) {
           });
       };
 
-      var port = 8000; var isNotFoundPort = true;
-      var openBrowser = true; var isNotFoundOpenBrowser = true;
-      process.argv.forEach(function(arg, i) {
-        if (isNotFoundPort && i >= 3 && !!arg.match(/^([0-9]+)$/)) {
-          port = arg;
-          isNotFoundPort = false;
-        } else if (isNotFoundOpenBrowser && i >= 3 && arg === '--no-open') {
-          openBrowser = false;
-          isNotFoundOpenBrowser = false;
-        }
-      });
-
       // Execute filewatcher here with transpiler
       var FileWatcher = require(path.join(__dirname, '..', 'node_modules', 'monaca-lib', 'src', 'localkit', 'fileWatcher'));
       var fileWatcherTranspiler = new FileWatcher();
@@ -103,7 +95,7 @@ ServeTask.run = function(taskName) {
         alive: true
       }, {
         name: 'http-server',
-        process: exec('node' + ' ' + path.join(__dirname, 'serve', 'node_modules', 'http-server', 'bin', 'http-server') + ' ' + path.join(process.cwd(), 'www') + ' -c-1 ' + (openBrowser ? ' -o ' : '') + ' -p ' + port, {cwd: __dirname}),
+        process: exec('node' + ' ' + path.join(__dirname, 'serve', 'node_modules', 'http-server', 'bin', 'http-server') + ' ' + path.join(process.cwd(), 'www') + ' -c-1 ' + (argv.open ? ' -o ' : '') + ' -p ' + (argv.port || 8000), {cwd: __dirname}),
         color: 'cyan',
         alive: true
       }


### PR DESCRIPTION
@masahirotanaka This adds the `--no-open` option. I didn't add `-no` because I think the short form should be only 1 letter (at least optimist lib is like that). I can add `-n` if you want. This also changes the normal usage from `monaca preview 8001` to `monaca preview -p 8001` (or `--port 8001`) but I guess that's fine.
