### PR TITLE
Analytics

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,11 +6,10 @@ var path = require('path'),
   Monaca = require('monaca-lib').Monaca,
   util = require(path.join(__dirname, 'util'));
 
-var monaca = new Monaca();
+var ConfigTask = {}, monaca;
 
-var ConfigTask = {};
-
-ConfigTask.run = function(taskName) {
+ConfigTask.run = function(taskName, info) {
+  monaca = new Monaca(info);
   var command = argv._[1];
 
   if (command === 'set' && argv._[2]) {
@@ -36,7 +35,16 @@ ConfigTask.showProxy = function() {
 };
 
 ConfigTask.setProxy = function(proxyServer) {
-  monaca.setConfig('http_proxy', proxyServer).then(
+  var report = {
+    event: 'proxy'
+  };
+
+  monaca.setConfig('http_proxy', proxyServer)
+  .then(
+    monaca.reportAnalytics.bind(monaca, report),
+    monaca.reportFail.bind(monaca, report)
+  )
+  .then(
     function(proxyServer) {
       util.success('Proxy server set to "' + proxyServer + '".');
     },

--- a/src/cordova.js
+++ b/src/cordova.js
@@ -2,13 +2,25 @@
 'use strict';
 
 var path = require('path'),
-  exec = require('child_process').exec;
+  exec = require('child_process').exec,
+  Monaca = require('monaca-lib').Monaca;
 
-var CordovaTask = {};
+var CordovaTask = {}, monaca;
 
-CordovaTask.run = function(taskName) {
+CordovaTask.run = function(taskName, info) {
+  monaca = new Monaca(info);
   var args = process.argv.length > 3 ? process.argv.slice(3).join(' ') : '';
   var cmd = path.join(__dirname, '..', 'node_modules', '.bin', 'cordova') + ' ' + taskName + ' ' + args;
+
+  var needReport = taskName === 'plugin' && process.argv[3], reportErrors = '';
+  var report = {
+    event: 'plugin',
+    arg1: args
+  };
+
+  if (needReport) {
+    monaca.reportAnalytics(report);
+  }
 
   var childProcess = exec(cmd);
 
@@ -18,13 +30,21 @@ CordovaTask.run = function(taskName) {
 
   childProcess.stderr.on('data', function(data) {
     if (data) {
+      reportErrors += data.toString();
       process.stderr.write(data.toString().error);
     }
   });
 
-  childProcess.on('exit', function(code) {
-    if (code !== 0) {
-      process.exit(code);
+  childProcess.on('exit', function(code, qwe) {
+    if (needReport) {
+      monaca[code ? 'reportFail' : 'reportFinish'](report, reportErrors).then(
+        process.exit.bind(process, code),
+        process.exit.bind(process, code)
+      );
+    } else {
+      if (code) {
+        process.exit(code);
+      }
     }
   });
 };

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -29,6 +29,10 @@ fs.readdirSync(path.join(__dirname, docsPath)).forEach(function(filename) {
 });
 
 var VERSION = require(path.join(__dirname, '..', 'package.json')).version;
+var info = {
+  clientType: 'cli',
+  clientVersion: VERSION
+};
 
 var Monaca = {
   _getTask: function() {
@@ -81,13 +85,13 @@ var Monaca = {
     }
 
     var runner = function(task) {
-      var result = (require(path.join(__dirname, task.set))).run(task.name);
+      var result = (require(path.join(__dirname, task.set))).run(task.name, info);
       Promise.resolve(result).then(function(result) {
         if (result && result.nextTask) {
           runner(result.nextTask);
         }
       })
-    };    
+    };
     runner(task);
   },
   printVersion: function() {

--- a/src/remote.js
+++ b/src/remote.js
@@ -76,7 +76,8 @@ RemoteTask.build = function() {
       function(info) {
         projectInfo = info;
         error = 'Upload failed: ';
-        return monaca.uploadProject(cwd);
+        return monaca.uploadProject(cwd)
+          .progress(util.displayProgress);
       }
     )
     // Uploading project to Monaca Cloud.
@@ -87,9 +88,7 @@ RemoteTask.build = function() {
           error = 'Unable to build this project: ';
           return monaca.checkBuildAvailability(projectInfo.projectId, params.platform, params.purpose);
         }
-      },
-      Q.reject,
-      util.displayProgress
+      }
     )
     // Checking build availabilty (if no browser).
     .then(
@@ -121,7 +120,8 @@ RemoteTask.build = function() {
           // Build project on Monaca Cloud and download it into ./build folder.
           util.print('\nBuilding project on Monaca Cloud...');
           error = 'Remote build failed:  ';
-          return monaca.buildProject(projectInfo.projectId, params);
+          return monaca.buildProject(projectInfo.projectId, params)
+            .progress(util.displayProgress);
         }
       }
     )
@@ -129,9 +129,7 @@ RemoteTask.build = function() {
     .then(
       function(result) {
         return result.binary_url ? monaca.getSessionUrl(result.binary_url) : Q.reject(result.error_message);
-      },
-      Q.reject,
-      util.displayProgress
+      }
     )
     // Getting session URL.
     .then(

--- a/src/sync.js
+++ b/src/sync.js
@@ -11,11 +11,10 @@ var inquirer = require('monaca-inquirer'),
   lib = require(path.join(__dirname, 'lib')),
   util = require(path.join(__dirname, 'util'));
 
-var monaca = new Monaca();
+var SyncTask = {}, monaca;
 
-var SyncTask = {};
-
-SyncTask.run = function(taskName) {
+SyncTask.run = function(taskName, info) {
+  monaca = new Monaca(info);
   if (taskName === 'debug') {
     return monaca.relogin().then(this.livesync.bind(this), function() {
       return util.displayLoginErrors();
@@ -37,48 +36,64 @@ SyncTask.run = function(taskName) {
 };
 
 SyncTask.load = function(action) {
-  var cwd, options = {};
+  var cwd, options = {}, error = '';
   options.dryrun = argv['dry-run'];
   options.delete = argv.delete;
   options.force = argv.force;
   options.action = action;
 
+  var report = {
+    event: action
+  };
+  monaca.reportAnalytics(report);
+
   lib.confirmOverwrite(options)
     // Waiting for user permission.
     .then(
       function() {
+        error = 'Unable to ' + action + ' project: ';
         return lib.findProjectDir(process.cwd(), monaca);
-      },
-      util.fail
+      }
     )
     // Checking project directory.
     .then(
       function(directory) {
+        error = 'Unable to create monaca project: ';
         cwd = directory;
+        
         if (action === 'upload') {
           return lib.assureMonacaProject(cwd, monaca);
         }
-      },
-      util.fail.bind(null, 'Unable to ' + action + ' project: ')
+      }
     )
     // Assuring this is a Monaca-like project (if uploading).
     .then(
       function() {
+        error = action.toUpperCase() + ' failed: ';
         return monaca[action + 'Project'](cwd, options);
-      },
-      util.fail.bind(null, 'Unable to create monaca project: ')
+      }
     )
     // Uploading/Downloading project to Monaca Cloud.
     .then(
-      lib.printSuccessMessage.bind(null, options),
-      util.fail.bind(null, action.toUpperCase() + ' failed: '),
+      monaca.reportFinish.bind(monaca, report),
+      monaca.reportFail.bind(monaca, report),
       util.displayProgress
+    )
+    // Reporting analytics
+    .then(
+      lib.printSuccessMessage.bind(null, options),
+      util.fail.bind(null, error)
     );
 };
 
 SyncTask.clone = function(saveCloudProjectID) {
   util.print('Fetching project list...');
   var project;
+
+  var report = {
+    event: 'clone'
+  };
+  monaca.reportAnalytics(report);
 
   monaca.getProjects()
     .then(
@@ -99,47 +114,60 @@ SyncTask.clone = function(saveCloudProjectID) {
             }
           }
         ]
-        ).then(function(answers) {
-          project = projects[answers.projectIndex];
-          project.destPath = answers.destPath;
-          project.absolutePath = path.resolve(answers.destPath);
-
-          return project;
-        });
+        ).then(
+          function(answers) {
+            project = projects[answers.projectIndex];
+            project.destPath = answers.destPath;
+            project.absolutePath = path.resolve(answers.destPath);
+            
+            report.arg1 = project.name;
+            return project;
+          }
+        );
       }
     )
     // Waiting for user input - Destination directory.
     .then(
       function() {
         util.print((saveCloudProjectID ? 'Cloning' : 'Importing') + ' \'' + project.name + '\' to ' + project.absolutePath);
-
         return monaca.cloneProject(project.projectId, project.destPath);
-      },
-      util.fail
+      }
     )
     // Cloning project.
+    .then(
+      monaca.reportFinish.bind(monaca, report),
+      monaca.reportFail.bind(monaca, report),
+      util.displayProgress
+    )
+    // Reporting analytics
     .then(
       function() {
         util.success('\nProject successfully ' + (saveCloudProjectID ? 'cloned' : 'imported') + ' from Monaca Cloud!');
 
         if (saveCloudProjectID) {
-          monaca.setProjectId(project.absolutePath, project.projectId).catch(function(error) {
+          return monaca.setProjectId(project.absolutePath, project.projectId).catch(function(error) {
             util.err('\nProject is cloned to given location but Cloud project ID for this project could not be saved. \nThis project is not linked with corresponding project on Monaca Cloud.');
           });
         }
       },
-      util.fail.bind(null, '\nClone failed: '),
-      util.displayProgress
+      util.fail.bind(null, '\nClone failed: ')
     );
 };
 
 SyncTask.livesync = function() {
   var localkit, nwError = false;
 
+  var report = {
+    event: 'debug'
+  };
+  monaca.reportAnalytics(report);
+
   try {
     localkit = new Localkit(monaca, false);
   } catch (error) {
-    util.fail('Unable to start debug: ', error);
+    return monaca
+      .reportFail(report, 'Unable to start debug: ' + util.parseError(error))
+      .catch(util.fail);
   }
 
   if (Object.keys(localkit.pairingKeys).length == 0) {
@@ -224,26 +252,26 @@ SyncTask.livesync = function() {
     projects.push('.');
   }
 
+  var error = 'Unable to add projects: ';
   localkit.setProjects(projects)
     // Adding projects.
     .then(
       function() {
         // Starting file watching
+        error = 'Unable to start file watching: ';
         return localkit.startWatch();
-      },
-      util.fail.bind(null, 'Unable to add projects: ')
+      }
     )
     .then(
       function() {
         // Starting HTTP server
+        error = 'Unable to start HTTP server: ';
         return localkit.startHttpServer({ httpPort: argv.port });
-      },
-      util.fail.bind(null, 'Unable to start file watching: ')
+      }
     )
     // Starting HTTP server.
     .then(
       function(server) {
-
         // Send "exit" event when program is terminated.
         process.on('SIGINT', function() {
           util.print('Stopping debug...');
@@ -252,9 +280,9 @@ SyncTask.livesync = function() {
         }.bind(localkit.projectEvents));
 
         util.print('Waiting for Monaca Debugger connecting to ' + server.address + ':' + server.port + '.');
+        error = 'Unable to start beacon transmitter: ';
         return localkit.startBeaconTransmitter();
-      },
-      util.fail.bind(null, 'Unable to start HTTP server: ')
+      }
     )
     // Starting beacon transmiter.
     .then(
@@ -262,9 +290,11 @@ SyncTask.livesync = function() {
         if (nwError) {
           util.warn('\nNode Webkit is not installed, so inspector capabilities will be disabled.\nPlease run "npm install nw" and restart the debug.\n');
         }
-
-      },
-      util.fail.bind(null, 'Unable to start beacon transmitter: ')
+      }
+    )
+    .then(
+      monaca.reportFinish.bind(monaca, report),
+      monaca.reportFail.bind(monaca, report)
     );
 
 };

--- a/src/sync.js
+++ b/src/sync.js
@@ -70,14 +70,14 @@ SyncTask.load = function(action) {
     .then(
       function() {
         error = action.toUpperCase() + ' failed: ';
-        return monaca[action + 'Project'](cwd, options);
+        return monaca[action + 'Project'](cwd, options)
+          .progress(util.displayProgress);
       }
     )
     // Uploading/Downloading project to Monaca Cloud.
     .then(
       monaca.reportFinish.bind(monaca, report),
-      monaca.reportFail.bind(monaca, report),
-      util.displayProgress
+      monaca.reportFail.bind(monaca, report)
     )
     // Reporting analytics
     .then(
@@ -130,14 +130,14 @@ SyncTask.clone = function(saveCloudProjectID) {
     .then(
       function() {
         util.print((saveCloudProjectID ? 'Cloning' : 'Importing') + ' \'' + project.name + '\' to ' + project.absolutePath);
-        return monaca.cloneProject(project.projectId, project.destPath);
+        return monaca.cloneProject(project.projectId, project.destPath)
+          .progress(util.displayProgress);
       }
     )
     // Cloning project.
     .then(
       monaca.reportFinish.bind(monaca, report),
-      monaca.reportFail.bind(monaca, report),
-      util.displayProgress
+      monaca.reportFail.bind(monaca, report)
     )
     // Reporting analytics
     .then(

--- a/src/util.js
+++ b/src/util.js
@@ -38,6 +38,18 @@ var fail = function() {
   process.exit(1);
 };
 
+var parseError = function(error) {
+  switch (typeof error) {
+    case 'object':
+      return error.message;
+    case 'array':
+      return error.join('\n');
+    default:
+      return error;
+  }
+};
+
+
 var displayObjectKeys = function(object) {
   println(
     Object.keys(object).map(function(file, index) {
@@ -153,6 +165,7 @@ module.exports = {
   warn: printwarn,
   success: printsuccess,
   fail: fail,
+  parseError: parseError,
   displayProgress: displayProgress,
   displayObjectKeys: displayObjectKeys,
   displayLoginErrors: displayLoginErrors,

--- a/src/util.js
+++ b/src/util.js
@@ -5,13 +5,8 @@ var Q = require('q');
 
 var _print = function(type, items) {
   var msg = '';
-
   for (var i = 0; i < items.length; i++) {
-    if (typeof items[i] === 'string') {
-      msg += items[i];
-    } else if (items[i] && typeof items[i] === 'object' && items[i].message) {
-      msg += items[i].message;
-    }
+    msg += parseError(items[i]);
   }
 
   process.stderr.write((type ? msg[type] : msg) + '\n');
@@ -41,9 +36,7 @@ var fail = function() {
 var parseError = function(error) {
   switch (typeof error) {
     case 'object':
-      return error.message;
-    case 'array':
-      return error.join('\n');
+      return Array.isArray(error) ? error.join('\n') : error.message;
     default:
       return error;
   }


### PR DESCRIPTION
@masahirotanaka This is the CLI part of the analytics.

Basically I had to remove all the `util.fail` and let the error bubble until the end in order to report it and then exit the process.

This PR also fixes the problem where progress for upload/download and remote-build was not displayed.

I didn't implement analytics for `monaca preview` yet since Bryan is modifying that file quite a lot. I will do it when his part is finished.
