### PR TITLE
New method to get webpack config file.

### DIFF
--- a/src/serve.js
+++ b/src/serve.js
@@ -80,7 +80,15 @@
           if (isTranspileEnabled) {
             // Webpack Route
             childProcessBin = monaca.getWebpackDevServerBinPath();
-            childProcess = exec(childProcessBin + (argv.open ? ' --open' : '') + ' --progress --config ' + path.join(process.cwd(), 'webpack.dev.config.js'), {
+
+            // Webpack config file path
+            try {
+              var webpackConfig = monaca.getWebpackConfigFile(process.cwd(), 'dev');
+            } catch(error) {
+              return Q.reject(error);
+            }
+
+            childProcess = exec(childProcessBin + (argv.open ? ' --open' : '') + ' --progress --config ' + webpackConfig, {
               env: extend({}, process.env, {
                 WP_HOST: host,
                 WP_PORT: argv.port


### PR DESCRIPTION
@masahirotanaka CLI part. Shows error on `preview` when there is no `webpack.dev.config.js`.
