### PR TITLE
Bumped built-in Cordova CLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v2.6.1
+----
+* Bumped built-in Cordova CLI dependency to 7.1.0.
+
 v2.6.0
 ----
 * Added React-Native Project Support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaca",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Monaca Command Line Tool",
   "bin": {
     "monaca": "bin/monaca"
@@ -31,7 +31,7 @@
   "dependencies": {
     "colors": "^0.6.2",
     "compare-versions": "3.0.1",
-    "cordova": "6.5.0",
+    "cordova": "7.1.0",
     "extend": "^2.0.0",
     "global-npm": "^0.3.0",
     "ip": "^1.1.5",


### PR DESCRIPTION
- Bumped built-in Cordova CLI version to 7.1.0
- Bumped Monaca CLI to 2.6.1