### PR TITLE
change default build directory

### DIFF
--- a/doc/tasks/sync.json
+++ b/doc/tasks/sync.json
@@ -58,6 +58,10 @@
     ],
     "options": [
       [
+        "--skipTranspile",
+        "do not transpile/build project before uploading."
+      ],
+      [
         "--delete",
         "deletes those files on Monaca cloud which are not present locally."
       ],

--- a/src/remote.js
+++ b/src/remote.js
@@ -181,8 +181,16 @@ RemoteTask.remote = function(task) {
             }
           }
 
-          shell.mkdir('-p', path.join(cwd, 'build'));
-          return path.join(cwd, 'build', filename);
+          let build_path = '';
+          try {
+            build_path = path.join( process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'], 'Desktop');
+          } catch (e) {
+            build_path = '/tmp/build';
+            console.log('could not get the desktop directory', e);
+            console.log('save to ', build_path);
+            shell.mkdir('-p', build_path);
+          }
+          return path.join(build_path, filename);
         });
       }
     )


### PR DESCRIPTION
- change defult build path to desktop
- add missing help to monaca upload

P.S: `monaca remote build` already has the `output` option to specify the output build.