### PR TITLE
Bind monaca-lib 2.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 CHANGELOG
 ====
 
+v2.7.11
+----
+* appended `path` to the `upload` and `download` request url (with `monaca-lib@2.7.11`)
+* return `upload` and `download` progress to `localkit` (with `monaca-lib@2.7.11`)
+* remove `platforms` from default `.monacaignore` for project with lower cordova version (with `monaca-lib@2.7.11`)
+
 v2.7.10
 ----
 * Modified `monaca preview` to include `loader.js` and `loader.css` to `index.html` (with `monaca-lib@2.7.10`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monaca",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3737,9 +3737,9 @@
       }
     },
     "monaca-lib": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/monaca-lib/-/monaca-lib-2.7.10.tgz",
-      "integrity": "sha512-xp9RUqvicF1re8bBkjcIn5RO3AU2O31DP0J5fzY6WICxh4/zBWq6kKRQcZz7Q55kA1Gbc5yWtcZiHClINmF8iQ==",
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/monaca-lib/-/monaca-lib-2.7.11.tgz",
+      "integrity": "sha512-0l+yiJ7NOfCVfcy08gmF66iSlZfLcz1CEt2LvbkvR6r929Y2y70OErrZjDY4dzNvjPfsSpxZofPLw0gkC6zHtg==",
       "requires": {
         "adbkit": "^2.2.1",
         "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaca",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "description": "Monaca Command Line Tool",
   "bin": {
     "monaca": "bin/monaca"
@@ -39,7 +39,7 @@
     "ip": "^1.1.5",
     "live-server": "1.2.0",
     "monaca-inquirer": "^1.0.4",
-    "monaca-lib": "^2.7.10",
+    "monaca-lib": "^2.7.11",
     "open": "0.0.5",
     "optimist": "^0.6.1",
     "portfinder": "^1.0.7",


### PR DESCRIPTION
* appended `path` to the `upload` and `download` request url (with `monaca-lib@2.7.11`)
* return `upload` and `download` progress to `localkit` (with `monaca-lib@2.7.11`)
* remove `platforms` from default `.monacaignore` for project with lower cordova version (with `monaca-lib@2.7.11`)